### PR TITLE
saveJSON modify to serialize numpy types

### DIFF
--- a/netpyne/sim/save.py
+++ b/netpyne/sim/save.py
@@ -33,10 +33,13 @@ from . import utils
 #------------------------------------------------------------------------------
 def saveJSON(fileName, data):
     import json, io
+    from .utils import NpSerializer
+
     with io.open(fileName, 'w', encoding='utf8') as fileObj:
         str_ = json.dumps(data,
                           indent=4, sort_keys=True,
-                          separators=(',', ': '), ensure_ascii=False)
+                          separators=(',', ': '), ensure_ascii=False,
+                          cls=NpSerializer)
         fileObj.write(to_unicode(str_))
 
 

--- a/netpyne/sim/utils.py
+++ b/netpyne/sim/utils.py
@@ -541,4 +541,19 @@ def clearAll ():
 
     import gc; gc.collect()
     
+#------------------------------------------------------------------------------
+# Create a subclass of json.JSONEncoder to convert numpy types in Python types
+#------------------------------------------------------------------------------
+import json
+import numpy as np
 
+class NpSerializer(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, np.integer):
+            return int(obj)
+        elif isinstance(obj, np.floating):
+            return float(obj)
+        elif isinstance(obj, np.ndarray):
+            return obj.tolist()
+        else:
+            return super(NpSerializer, self).default(obj)


### PR DESCRIPTION
I modify the save.py to fix the JSON serialization of numpy types @rodriguez-facundo 
If you add the next lines to HHTut_run.py example:

```python
print(type(sim.allSimData['spkt']))
sim.allSimData['spkt'] = np.array(sim.allSimData['spkt'], dtype='int')
print(type(sim.allSimData['spkt']))
sim.saveJSON('pepe.json',sim.allSimData['spkt'])
```
You raise the error:
![errorJSON](https://user-images.githubusercontent.com/56417833/68721920-bba8fe00-0592-11ea-84de-b88962df1c59.jpeg)
